### PR TITLE
Fix "can't set attribute" error

### DIFF
--- a/chronograph/chronograph.py
+++ b/chronograph/chronograph.py
@@ -88,7 +88,7 @@ class Chronograph():
         """
         self.name = name
         self.header = name if name else "Unnamed Chronograph"
-        self.timing_data = []
+        self._timing_data = []
         self.verbosity = verbosity
         self.throw_exceptions = throw_exceptions
 
@@ -202,7 +202,11 @@ class Chronograph():
 
         :return: (JSON array of dicts)
         """
-        return self.timing_data
+        return self._timing_data
+
+    @timing_data.setter
+    def timing_data(self, new_data):
+        self._timing_data = new_data
 
     def report(self, printout=False):
         """


### PR DESCRIPTION
Hi,

I got the following error when using chronograph with Python 3.7 : 
```
File "/usr/local/lib/python3.7/dist-packages/chronograph/chronograph.py", line 36, in get_chronograph
    all_chronographs[name] = Chronograph(name, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/chronograph/chronograph.py", line 91, in __init__
    self.timing_data = []
AttributeError: can't set attribute
```
This PR fix this error. Would you consider merging it and deploy a new Pip release ?